### PR TITLE
feat(DATAGO-118293): Add platform database configuration to Docker Compose deployment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -61,6 +61,7 @@ EXTERNAL_BROKER_VPN=default
 # Ignored when using compose-database.yml
 # ==========================================
 EXTERNAL_WEB_UI_DATABASE_URL=postgresql+psycopg2://user:password@dbhost:5432/sam_webui
+EXTERNAL_PLATFORM_DATABASE_URL=postgresql+psycopg2://user:password@dbhost:5432/sam_platform
 EXTERNAL_ORCHESTRATOR_DATABASE_URL=postgresql+psycopg2://user:password@dbhost:5432/sam_orchestrator
 
 # ==========================================

--- a/compose.database.yml
+++ b/compose.database.yml
@@ -10,6 +10,7 @@ services:
     environment:
       # Override external database settings to use managed database
       WEB_UI_GATEWAY_DATABASE_URL: postgresql+psycopg2://webui:webui@postgres:5432/webui
+      PLATFORM_DATABASE_URL: postgresql+psycopg2://platform:platform@postgres:5432/platform
       ORCHESTRATOR_DATABASE_URL: postgresql+psycopg2://orchestrator:orchestrator@postgres:5432/orchestrator
 
   postgres:
@@ -36,6 +37,9 @@ configs:
     content: |
       CREATE USER webui WITH PASSWORD 'webui';
       CREATE DATABASE webui OWNER webui;
+
+      CREATE USER platform WITH PASSWORD 'platform';
+      CREATE DATABASE platform OWNER platform;
 
       CREATE USER orchestrator WITH PASSWORD 'orchestrator';
       CREATE DATABASE orchestrator OWNER orchestrator;

--- a/compose.yml
+++ b/compose.yml
@@ -23,6 +23,7 @@ services:
     environment:
       NAMESPACE: ${NAMESPACE}
       WEB_UI_GATEWAY_DATABASE_URL: ${EXTERNAL_WEB_UI_DATABASE_URL}
+      PLATFORM_DATABASE_URL: ${EXTERNAL_PLATFORM_DATABASE_URL}
       ORCHESTRATOR_DATABASE_URL: ${EXTERNAL_ORCHESTRATOR_DATABASE_URL}
       S3_BUCKET_NAME: ${EXTERNAL_S3_BUCKET_NAME}
       S3_ENDPOINT_URL: ${EXTERNAL_S3_ENDPOINT_URL}
@@ -342,6 +343,9 @@ configs:
               type: "sql"
               database_url: "$${WEB_UI_GATEWAY_DATABASE_URL}"
               default_behavior: "PERSISTENT"
+
+            platform_service:
+              database_url: "$${PLATFORM_DATABASE_URL}"
 
             task_logging:
               enabled: true


### PR DESCRIPTION
## Summary
- Added third platform database alongside existing webui and orchestrator databases
- Updated compose.database.yml to create platform database and user
- Added PLATFORM_DATABASE_URL environment variable configuration
- Updated webui_backend.yml config to include platform_service section
- Added external platform database configuration to .env.template

## Changes
This PR mirrors the Kubernetes Helm chart changes from sam-kubernetes#16, bringing the same platform database configuration to the Docker Compose quickstart deployment.

### Files Modified:
- **compose.database.yml**: Added platform database initialization
- **compose.yml**: Added PLATFORM_DATABASE_URL env var and platform_service config
- **.env.template**: Added EXTERNAL_PLATFORM_DATABASE_URL for BYO mode

## Database Summary
The deployment now creates three PostgreSQL databases:
1. **webui** - Web UI Gateway data
2. **platform** - Platform service data (NEW)
3. **orchestrator** - Orchestrator Agent data

Each database has dedicated credentials and supports both managed (local) and BYO (external) deployment modes.