### PR TITLE
fix(DATAGO-128278): Use official Docker hub seaweedfs image

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,7 +17,7 @@ SAM_DEPLOYER_IMAGE=gcr.io/gcp-maas-prod/sam-agent-deployer
 SAM_DEPLOYER_TAG=1.1.3
 
 POSTGRES_TAG=18.0-trixie
-SEAWEEDFS_TAG=3.97-compliant
+SEAWEEDFS_TAG=3.97
 
 # ==========================================
 # SAM NAMESPACE

--- a/compose.database.yml
+++ b/compose.database.yml
@@ -11,7 +11,6 @@ services:
       WEB_UI_GATEWAY_DATABASE_URL: postgresql+psycopg2://webui:webui@postgres:5432/webui
       PLATFORM_DATABASE_URL: postgresql+psycopg2://platform:platform@postgres:5432/platform
       ORCHESTRATOR_DATABASE_URL: postgresql+psycopg2://orchestrator:orchestrator@postgres:5432/orchestrator
-      PLATFORM_DATABASE_URL: postgresql+psycopg2://platform:platform@postgres:5432/platform
 
   postgres:
     image: postgres:${POSTGRES_TAG}
@@ -43,9 +42,6 @@ configs:
 
       CREATE USER orchestrator WITH PASSWORD 'orchestrator';
       CREATE DATABASE orchestrator OWNER orchestrator;
-
-      CREATE USER platform WITH PASSWORD 'platform';
-      CREATE DATABASE platform OWNER platform;
 
 volumes:
   postgres:

--- a/compose.storage.yml
+++ b/compose.storage.yml
@@ -16,7 +16,7 @@ services:
       AWS_SECRET_ACCESS_KEY: sam
 
   seaweedfs:
-    image: ghcr.io/solacedev/chrislusf/seaweedfs:${SEAWEEDFS_TAG}
+    image: chrislusf/seaweedfs:${SEAWEEDFS_TAG}
     networks:
       - sam
     command: >
@@ -38,7 +38,7 @@ services:
     restart: unless-stopped
 
   seaweedfs-init:
-    image: ghcr.io/solacedev/chrislusf/seaweedfs:${SEAWEEDFS_TAG}
+    image: chrislusf/seaweedfs:${SEAWEEDFS_TAG}
     networks:
       - sam
     environment:


### PR DESCRIPTION
## Changes

- Replace `ghcr.io/solacedev/chrislusf/seaweedfs` with `chrislusf/seaweedfs` (official Docker Hub image) in `compose.storage.yml`

- Update `SEAWEEDFS_TAG` from `3.97-compliant` to `3.97` in `.env.template` since the `-compliant` tag only existed on the GHCR mirror

- Remove duplicate `PLATFORM_DATABASE_URL` entry and initialization query in `compose.database.yml`

## Tests

- [X] Verify `podman pull chrislusf/seaweedfs:3.97` succeeds
- [X] Verify setup and start scripts create a working containerized version of SAM
- [X] Completed actions relating to file CRUD in the webui